### PR TITLE
fix(windows): invoke inodejskernel with .cmd at end

### DIFF
--- a/src/install-kernel.js
+++ b/src/install-kernel.js
@@ -9,9 +9,12 @@ if (!dataDirs[0]) {
 }
 
 const baseDir = path.join(dataDirs[0], 'kernels', 'nodejs')
+const baseCommand = 'inodejskernel'
+const command = process.platform === 'win32' ? `${baseCommand}.cmd` : baseCommand
+
 const kernelSpec = JSON.stringify({
   argv: [
-    "inodejskernel",
+    command,
     "{connection_file}"
   ],
   "display_name": "Node.js",


### PR DESCRIPTION
This makes inodejs work out of the box on Windows (at least with nteract).
